### PR TITLE
Fix: Blog link references

### DIFF
--- a/gcweb/index-en.md
+++ b/gcweb/index-en.md
@@ -5,7 +5,7 @@ permalink: "gcweb/index-en.html"
 title: "Canada.ca theme"
 language: en
 altLangPrefix: index
-dateModified: "2014-05-27"
+dateModified: "2014-08-16"
 description: "GC Web Usability theme - Jekyll variant - Web Experience Toolkit (WET)"
 ---
 
@@ -19,4 +19,4 @@ description: "GC Web Usability theme - Jekyll variant - Web Experience Toolkit (
 
 ## Blog posts
 
-* [Blog post](../2013-06-11-gcweb-en.html)
+* [Blog post](../2013-06-16-gcweb-en.html)

--- a/gcweb/index-fr.md
+++ b/gcweb/index-fr.md
@@ -5,7 +5,7 @@ permalink: "gcweb/index-fr.html"
 title: "Thème Canada.ca"
 language: fr
 altLangPrefix: index
-dateModified: "2014-05-27"
+dateModified: "2014-08-16"
 description: "Thème Canada.ca - Variant pour Jekyll - Boîte à outils de l'expérience Web (BOEW)"
 ---
 
@@ -19,4 +19,4 @@ description: "Thème Canada.ca - Variant pour Jekyll - Boîte à outils de l'exp
 
 ## Articles de blogue
 
-* [Article de blogue](../2013-06-11-gcweb-fr.html)
+* [Article de blogue](../2013-06-16-gcweb-fr.html)

--- a/theme-base/index-en.md
+++ b/theme-base/index-en.md
@@ -5,7 +5,7 @@ permalink: "theme-base/index-en.html"
 title: "Base theme"
 language: en
 altLangPrefix: index
-dateModified: "2014-05-27"
+dateModified: "2014-08-16"
 description: "Base theme - Jekyll variant - Web Experience Toolkit (WET)"
 ---
 
@@ -19,4 +19,4 @@ description: "Base theme - Jekyll variant - Web Experience Toolkit (WET)"
 
 ## Blog posts
 
-* [Blog post](../2013-06-11-theme-base-en.html)
+* [Blog post](../2013-06-14-theme-base-en.html)

--- a/theme-base/index-fr.md
+++ b/theme-base/index-fr.md
@@ -5,7 +5,7 @@ permalink: "theme-base/index-fr.html"
 title: "Thème de la base"
 language: fr
 altLangPrefix: index
-dateModified: "2014-05-27"
+dateModified: "2014-08-16"
 description: "Thème de la base - Variant pour Jekyll - Boîte à outils de l'expérience Web (BOEW)"
 ---
 
@@ -19,4 +19,4 @@ description: "Thème de la base - Variant pour Jekyll - Boîte à outils de l'ex
 
 ## Articles de blogue
 
-* [Article de blogue](../2013-06-11-theme-base-fr.html)
+* [Article de blogue](../2013-06-14-theme-base-fr.html)

--- a/theme-gcwu-fegc/index-en.md
+++ b/theme-gcwu-fegc/index-en.md
@@ -5,7 +5,7 @@ permalink: "theme-gcwu-fegc/index-en.html"
 title: "GC Web Usability theme"
 language: en
 altLangPrefix: index
-dateModified: "2014-05-27"
+dateModified: "2014-08-16"
 description: "GC Web Usability theme - Jekyll variant - Web Experience Toolkit (WET)"
 ---
 
@@ -19,4 +19,4 @@ description: "GC Web Usability theme - Jekyll variant - Web Experience Toolkit (
 
 ## Blog posts
 
-* [Blog post](../2013-06-11-theme-gcwu-fegc-en.html)
+* [Blog post](../2013-06-13-theme-gcwu-fegc-en.html)

--- a/theme-gcwu-fegc/index-fr.md
+++ b/theme-gcwu-fegc/index-fr.md
@@ -5,7 +5,7 @@ permalink: "theme-gcwu-fegc/index-fr.html"
 title: "Thème de la facilité d’emploi Web du gouvernement du Canada"
 language: fr
 altLangPrefix: index
-dateModified: "2014-05-27"
+dateModified: "2014-08-16"
 description: "Thème de la facilité d’emploi Web du gouvernement du Canada - Variant pour Jekyll - Boîte à outils de l'expérience Web (BOEW)"
 ---
 
@@ -19,4 +19,4 @@ description: "Thème de la facilité d’emploi Web du gouvernement du Canada - 
 
 ## Articles de blogue
 
-* [Article de blogue](../2013-06-11-theme-gcwu-fegc-fr.html)
+* [Article de blogue](../2013-06-13-theme-gcwu-fegc-fr.html)


### PR DESCRIPTION
The posts had different dates, but all the URLs were pointing to "2013-06-11".

These links should eventually get replaced with the http://jekyllrb.com/docs/templates/#post-url helper 
